### PR TITLE
add timeout input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: "Comma seperated list of acceptable file extensions for credential checks"
     required: false
     default: ""
+  timeout:
+    description: "docker timeout. e.g) 5s, 5m..."
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -65,6 +69,7 @@ runs:
         DOCKLE_ACCEPT_KEYS: ${{ inputs.accept-keywords }}
         DOCKLE_ACCEPT_FILES: ${{ inputs.accept-filenames }}
         DOCKLE_ACCEPT_FILE_EXTENSIONS: ${{ inputs.accept-extensions }}
+        DOCKLE_TIMEOUT: ${{ inputs.timeout }}
       run: |
         # Exit always with exit 0 to continue with the stdout version
         dockle -f "$REPORT_FORMAT" -o "$REPORT_NAME.$REPORT_FORMAT" --exit-code 0 --exit-level "$FAILURE_THRESHOLD" "$IMAGE"


### PR DESCRIPTION
Hi @erzz thanks for this convenient action!

I ran into a timeout error. My images were rather big and because of that dockle showed following error:
```
FATAL	Pull it with "docker pull <image tag>" or "dockle --timeout 600s" to increase the timeout
```
I've added an additional optional `timeout` input for the action that sets the env var `DOCKLE_TIMEOUT`. Now dockle has all the time it needs for my images. :)