### PR TITLE
fix: set default DOCKLE_HOST

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: "docker timeout. e.g) 5s, 5m..."
     required: false
     default: "10m"
+  dockle-host:
+    description: "Override the DOCKLE_HOST environment variable"
+    required: false
+    default: "unix:///var/run/docker.sock"
 runs:
   using: "composite"
   steps:
@@ -70,6 +74,7 @@ runs:
         DOCKLE_ACCEPT_FILES: ${{ inputs.accept-filenames }}
         DOCKLE_ACCEPT_FILE_EXTENSIONS: ${{ inputs.accept-extensions }}
         DOCKLE_TIMEOUT: ${{ inputs.timeout }}
+        DOCKLE_HOST: ${{ inputs.dockle-host }}
       run: |
         # Exit always with exit 0 to continue with the stdout version
         dockle -f "$REPORT_FORMAT" -o "$REPORT_NAME.$REPORT_FORMAT" --exit-code 0 --exit-level "$FAILURE_THRESHOLD" "$IMAGE"


### PR DESCRIPTION
According to https://github.com/goodwithtech/dockle/issues/188#issuecomment-1173841064

I am not sure why this issue now started to happen, but it is here now :shrug: Maybe `ubuntu-latest` now behaves differently?