### PR TITLE
fix: remove sudo requirement from dockle installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,10 @@ runs:
         if [ "$DOCKLE_VERSION" = "latest" ]; then
           export DOCKLE_VERSION=$(curl -H "Authorization: token ${GH_TOKEN}" --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
         fi
-        curl -L -o dockle.deb https://github.com/goodwithtech/dockle/releases/download/v${DOCKLE_VERSION}/dockle_${DOCKLE_VERSION}_Linux-64bit.deb && sudo dpkg -i dockle.deb && rm dockle.deb
+        INSTALL_DIR="${RUNNER_TEMP:-/tmp}/dockle"
+        mkdir -p "$INSTALL_DIR"
+        curl -L "https://github.com/goodwithtech/dockle/releases/download/v${DOCKLE_VERSION}/dockle_${DOCKLE_VERSION}_Linux-64bit.tar.gz" | tar xz -C "$INSTALL_DIR"
+        echo "$INSTALL_DIR" >> "$GITHUB_PATH"
     - name: Run Dockle
       shell: bash
       id: dockle


### PR DESCRIPTION
## Summary

- Replaces `.deb` package installation (`sudo dpkg -i`) with `.tar.gz` extraction to `$RUNNER_TEMP/dockle`
- Adds the install directory to `$GITHUB_PATH` so `dockle` is available in subsequent steps
- Eliminates the need for passwordless sudo on the runner

## Motivation

When using Security tools that disable passwordless sudo by default on GitHub Actions runners. The previous `sudo dpkg -i` approach fails in these environments. Since dockle is a standalone binary, there's no reason to use system-level package installation — extracting the tarball to a user-writable directory works identically.

## Changes

**Before:**
```bash
curl -L -o dockle.deb .../dockle_${VERSION}_Linux-64bit.deb && sudo dpkg -i dockle.deb && rm dockle.deb
```

**After:**
```bash
INSTALL_DIR="${RUNNER_TEMP:-/tmp}/dockle"
mkdir -p "$INSTALL_DIR"
curl -L ".../dockle_${VERSION}_Linux-64bit.tar.gz" | tar xz -C "$INSTALL_DIR"
echo "$INSTALL_DIR" >> "$GITHUB_PATH"
```